### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/template-1/components/Blog.tsx
+++ b/template-1/components/Blog.tsx
@@ -15,7 +15,7 @@ export default function Blog() {
             <img
               role="presentation"
               className="object-cover w-full rounded h-44 "
-              src="https://source.unsplash.com/random/481x361"
+              src="https://picsum.photos/seed/dev-ui-blog-1/481/361"
             />
             <div className="p-6 space-y-2">
               <h3 className="text-2xl font-semibold group-hover:underline group-focus:underline">
@@ -39,7 +39,7 @@ export default function Blog() {
             <img
               role="presentation"
               className="object-cover w-full rounded h-44 "
-              src="https://source.unsplash.com/random/482x362"
+              src="https://picsum.photos/seed/dev-ui-blog-2/482/362"
             />
             <div className="p-6 space-y-2">
               <h3 className="text-2xl font-semibold group-hover:underline group-focus:underline">
@@ -63,7 +63,7 @@ export default function Blog() {
             <img
               role="presentation"
               className="object-cover w-full rounded h-44 "
-              src="https://source.unsplash.com/random/483x363"
+              src="https://picsum.photos/seed/dev-ui-blog-3/483/363"
             />
             <div className="p-6 space-y-2">
               <h3 className="text-2xl font-semibold group-hover:underline group-focus:underline">


### PR DESCRIPTION
`template-1/components/Blog.tsx` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces the three deprecated grid placeholder URLs in `template-1/Blog.tsx` with seeded `picsum.photos` URLs so the blog grid renders distinct images again.

#### Replacement details

Each cell uses a unique `seed/dev-ui-blog-N` so the three grid images stay visually distinct (the original behaviour). Same dimensions.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
